### PR TITLE
Port to Plasma 6 + fix KDE store packaging (closes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # Claude Code local config - DO NOT COMMIT
 CLAUDE.md
 .claude/
+
+# Build artifacts
+*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# Claude Code local config - DO NOT COMMIT
+CLAUDE.md
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Fishy Splash Screen - Plasma 6 Port
+
+The "Fishy" splash screen features a cute animated fish swimming across your screen during system startup. This version has been updated to work with **KDE Plasma 6**, which uses Qt6 instead of Qt5.
+
+**Original creator:** KartikSindura  
+**Original repository:** https://github.com/KartikSindura/fishy
+
+## Fixes Made for Plasma 6
+
+- Updated QML imports from Qt5 to Qt6 for Plasma 6 compatibility
+- Fixed directory structure issues
+- Corrected the file organization to match KDE Plasma 6 requirements
+- Updated metadata.json for proper Plasma 6 recognition
+
+## Installation
+
+### Manual Installation
+
+1. Download or clone this repository
+2. Extract the contents to `~/.local/share/plasma/look-and-feel/fishy/`
+3. Refresh the KDE cache: `kbuildsycoca6`
+4. Go to **System Settings > Appearance > Splash Screen**
+5. Select "Fishy" from the list of available splash screens
+
+### KDE Store
+This splash screen will be available on the KDE Store soon!
+
+## License
+This splash screen is licensed under the GNU General Public License v3.0 (GPL-3.0), the same license as the original work. See the LICENSE file for more details.
+
+## Credits
+
+- **Original splash screen created by:** KartikSindura
+- **Plasma 6 compatibility port by:** f4mrfaux

--- a/README.md
+++ b/README.md
@@ -25,8 +25,18 @@ The "Fishy" splash screen features a cute animated fish swimming across your scr
 ### KDE Store
 This splash screen will be available on the KDE Store soon!
 
+## Packaging for the KDE Store
+
+To rebuild the upload archive:
+
+```bash
+./scripts/package.sh
+```
+
+This produces `fishy-plasma6.tar.gz` with a flat structure. Upload that archive directly to store.kde.org — do not wrap it in an additional parent folder, or KNewStuff will install it to a nested path (see issue #3).
+
 ## License
-This splash screen is licensed under the GNU General Public License v3.0 (GPL-3.0), the same license as the original work. See the LICENSE file for more details.
+This splash screen is licensed under the GNU General Public License v2 or later (GPLv2+), the same license as the original work. See the LICENSE file for more details.
 
 ## Credits
 

--- a/contents/splash/Splash.qml
+++ b/contents/splash/Splash.qml
@@ -1,6 +1,6 @@
-
 /*
  *   Copyright 2014 Marco Martin <mart@kde.org>
+ *   Modified for Plasma 6 compatibility
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License version 2,
@@ -17,13 +17,14 @@
  *   Free Software Foundation, Inc.,
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import QtQuick 2.5
-import QtQuick.Window 2.2
+import QtQuick
+import QtQuick.Window
 
 Rectangle {
     id: root
     color: "#010302"
     property int stage
+    property int sizeAnim: 500
 
     onStageChanged: {
         if (stage == 1) {
@@ -49,33 +50,29 @@ Rectangle {
         }
 
         Rectangle {
-
-        property int sizeAnim: 500
-
-        id: imageSource
-        width:  sizeAnim
-        height: sizeAnim
-        color:  "transparent"
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
-        clip: true;
-
-        AnimatedImage {
-            id: face
-            source: "images/fish.gif"
-            paused: false
+            id: imageSource
+            width: sizeAnim
+            height: sizeAnim
+            color: "transparent"
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
-            width:  imageSource.sizeAnim - 2
-            height: imageSource.sizeAnim - 2
-            smooth: true
-            visible: true
-         }
-    }
+            clip: true
 
-       Image {
+            AnimatedImage {
+                id: face
+                source: "images/fish.gif"
+                paused: false
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
+                width: sizeAnim
+                height: sizeAnim
+                smooth: true
+                visible: true
+            }
+        }
+
+        Image {
             id: busyIndicator
-            //in the middle of the remaining space
             y: parent.height - 200
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.margins: units.gridUnit
@@ -95,11 +92,9 @@ Rectangle {
             spacing: units.smallSpacing*3
             anchors {
                 bottom: parent.bottom
-                // right: parent.right
                 margins: units.gridUnit
             }
             anchors.horizontalCenter: parent.horizontalCenter
-
         }
     }
 

--- a/license
+++ b/license
@@ -1,0 +1,37 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+[...]
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you

--- a/metadata.json
+++ b/metadata.json
@@ -1,18 +1,19 @@
 {
-  "KPackageStructure": "Plasma/LookAndFeel",
-  "KPlugin": {
-    "Authors": [
-      {
-        "Email": "kartik",
-        "Name": "kartik.sindura@gmail.com"
-      }
-    ],
-    "Category": "",
-    "Description": "Fishbowl for Plasma 6",
-    "Id": "fishy",
-    "License": "GPLv2+",
-    "Name": "Fishbowl"
-  },
-  "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
-  "X-Plasma-APIVersion": "2"
+    "KPackageStructure": "Plasma/LookAndFeel/Splash",
+    "KPlugin": {
+        "Authors": [
+            {
+                "Email": "null",
+                "Name": "KartikSindura"
+            }
+        ],
+        "Category": "",
+        "Description": "a fishy splashscreen for Plasma 6,Original repository at https://github.com/KartikSindura/fishy. i love this splashscreen, but that's SC is abadoned for Plasma 5. its experimental migration to plasma 6. if you had anny issue, please touch me at ln8ybrhq7@mozmail.com",
+        "Id": "fishy",
+        "License": "GPLv3",
+        "Name": "Fishy",
+        "Website": "null"
+    },
+    "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
+    "X-Plasma-APIVersion": "2"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,16 +3,15 @@
     "KPlugin": {
         "Authors": [
             {
-                "Email": "null",
+                "Email": "kartik.sindura@gmail.com",
                 "Name": "KartikSindura"
             }
         ],
         "Category": "",
-        "Description": "a fishy splashscreen for Plasma 6,Original repository at https://github.com/KartikSindura/fishy. i love this splashscreen, but that's SC is abadoned for Plasma 5. its experimental migration to plasma 6. if you had anny issue, please touch me at ln8ybrhq7@mozmail.com",
+        "Description": "Fishbowl splash screen for KDE Plasma 6",
         "Id": "fishy",
-        "License": "GPLv3",
-        "Name": "Fishy",
-        "Website": "null"
+        "License": "GPLv2+",
+        "Name": "Fishy"
     },
     "Keywords": "Desktop;Workspace;Appearance;Look and Feel;Logout;Lock;Suspend;Shutdown;Hibernate;",
     "X-Plasma-APIVersion": "2"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Build a Plasma 6 look-and-feel tarball for upload to store.kde.org.
+#
+# Produces fishy-plasma6.tar.gz with a flat structure (no wrapper folder),
+# so KNewStuff resolves the install path via metadata.json's KPlugin.Id
+# and unpacks correctly to:
+#
+#   ~/.local/share/plasma/look-and-feel/fishy/
+#
+# Fixes upstream issue #3: tarballs that include a wrapper directory cause
+# nested install paths like UcTcDh-fishbowl/fishy/ when users install via
+# Plasma's "Get New Splashscreens" UI.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+OUT=fishy-plasma6.tar.gz
+rm -f "$OUT"
+
+tar -czf "$OUT" \
+    --exclude='.git' \
+    --exclude='.git/*' \
+    --exclude='.claude' \
+    --exclude='.claude/*' \
+    --exclude='.gitignore' \
+    --exclude='.qmlls.ini' \
+    --exclude='scripts' \
+    --exclude='scripts/*' \
+    --exclude='*.tar.gz' \
+    metadata.json contents license README.md
+
+echo "Built: $OUT"
+echo
+echo "Archive contents:"
+tar -tzf "$OUT"
+echo
+echo "Upload $OUT to store.kde.org as-is. Do not wrap it in another folder."


### PR DESCRIPTION
Resubmitting the Plasma 6 port (the previous PR #4 was auto-closed when I renamed the source branch on my fork — that was my mistake, not a withdrawal). This version also addresses #3.

## What's in this PR

**Plasma 6 compatibility** (existing work from #4)
- QML imports updated for Qt6
- `metadata.json` uses `Plasma/LookAndFeel/Splash` so Plasma 6 recognizes it as a splash
- Directory layout matches what Plasma 6 expects
- Tested on Plasma 6.4.4

**Metadata cleanup**
- `License`: `GPLv2+` (was `GPLv3` in the fork) to match the upstream LICENSE file
- `Description`: replaced with a concise summary (the fork had a longer prose blurb containing a private email)
- Drop literal `"null"` strings from `Email` / `Website` fields
- `Author.Email` restored to the address visible in your original metadata

**Fix for #3 — KDE store install path**

The reported `UcTcDh-fishbowl/fishy/` nested-install path is caused by uploading a tarball that includes a wrapper directory. KNewStuff downloads the store archive, extracts it, and then uses `metadata.json`'s `KPlugin.Id` (\`fishy\`) to determine the final folder name — but if the archive itself wraps everything in another directory, that extra layer survives the install.

Added \`scripts/package.sh\` which produces a flat-structured tarball:

\`\`\`
metadata.json
contents/
contents/splash/Splash.qml
contents/splash/images/...
contents/previews/splash.png
license
README.md
\`\`\`

Uploading the output of this script to store.kde.org should produce a clean \`~/.local/share/plasma/look-and-feel/fishy/\` install.

README documents the packaging step. `*.tar.gz` is gitignored so the build artifact doesn't get committed by accident.

## Files

| File | Change |
|---|---|
| `metadata.json` | Cleaner description, real email, license aligned |
| `README.md` | License correction; new "Packaging for the KDE Store" section |
| `scripts/package.sh` | New — builds the store-ready tarball |
| `.gitignore` | Ignore `*.tar.gz` |
| QML / layout changes | From the original port commits (already in #4) |

Happy to split this into separate PRs if you'd prefer to review the port and the #3 fix independently.